### PR TITLE
Créer éditeur de scène et gérer runtime

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -52,3 +52,42 @@ class EventCommand {
   String code; // e.g., 'ShowText', 'ControlSwitch', 'TransferPlayer'
   final Map<String, dynamic> params;
 }
+
+// Scene editor models
+
+enum SceneObjectKind { sprite2D, model3D, light, camera, sound }
+
+class SceneObject {
+  SceneObject({
+    required this.id,
+    required this.name,
+    required this.kind,
+    required this.x,
+    required this.y,
+    this.asset = '',
+    Map<String, dynamic>? props,
+  }) : props = props ?? <String, dynamic>{};
+
+  String id;
+  String name;
+  SceneObjectKind kind;
+  int x;
+  int y;
+  String asset;
+  final Map<String, dynamic> props;
+}
+
+class SceneData {
+  SceneData({required this.name, List<SceneObject>? objects})
+      : objects = objects ?? <SceneObject>[];
+
+  String name;
+  final List<SceneObject> objects;
+
+  SceneObject? findObjectAt(int x, int y) {
+    for (final obj in objects) {
+      if (obj.x == x && obj.y == y) return obj;
+    }
+    return null;
+  }
+}

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -1,0 +1,232 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'models.dart';
+
+class RuntimePreviewPage extends StatefulWidget {
+  const RuntimePreviewPage({super.key, required this.mapData, required this.scene});
+
+  final MapData mapData;
+  final SceneData scene;
+
+  @override
+  State<RuntimePreviewPage> createState() => _RuntimePreviewPageState();
+}
+
+class _RuntimePreviewPageState extends State<RuntimePreviewPage> {
+  final FocusNode _focusNode = FocusNode();
+  int playerX = 2;
+  int playerY = 2;
+  String? message;
+  bool actionRequested = false;
+  String? lastStepKey; // to avoid retrigger on same tile
+  final Set<String> executedAutorun = <String>{};
+  Timer? _tick;
+
+  static const double tileSize = 24.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tick = Timer.periodic(const Duration(milliseconds: 100), (_) => _update());
+  }
+
+  @override
+  void dispose() {
+    _tick?.cancel();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _update() {
+    // Autorun events
+    for (final e in widget.mapData.events) {
+      final key = 'Autorun:${e.x}:${e.y}';
+      if (e.pages.isNotEmpty && e.pages.first.trigger == 'Autorun' && !executedAutorun.contains(key)) {
+        executedAutorun.add(key);
+        _runEvent(e);
+      }
+    }
+
+    // PlayerTouch
+    final stepKey = '${playerX}:${playerY}';
+    if (stepKey != lastStepKey) {
+      lastStepKey = stepKey;
+      for (final e in widget.mapData.events) {
+        if (e.x == playerX && e.y == playerY) {
+          if (e.pages.isNotEmpty && e.pages.first.trigger == 'PlayerTouch') {
+            _runEvent(e);
+          }
+        }
+      }
+    }
+
+    // ActionButton
+    if (actionRequested) {
+      actionRequested = false;
+      for (final e in widget.mapData.events) {
+        if (e.x == playerX && e.y == playerY) {
+          if (e.pages.isNotEmpty && e.pages.first.trigger == 'ActionButton') {
+            _runEvent(e);
+            break;
+          }
+        }
+      }
+    }
+
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _runEvent(EventData e) async {
+    if (e.pages.isEmpty) return;
+    final page = e.pages.first;
+    for (final cmd in page.commands) {
+      if (cmd.code == 'ShowText') {
+        final text = (cmd.params['text'] ?? '').toString();
+        setState(() => message = text);
+        await Future<void>.delayed(const Duration(milliseconds: 1500));
+        if (!mounted) return;
+        setState(() => message = null);
+      } else if (cmd.code == 'TransferPlayer') {
+        final nx = (cmd.params['x'] ?? playerX) as int;
+        final ny = (cmd.params['y'] ?? playerY) as int;
+        setState(() {
+          playerX = nx.clamp(0, widget.mapData.width - 1);
+          playerY = ny.clamp(0, widget.mapData.height - 1);
+        });
+      }
+    }
+  }
+
+  void _onKey(RawKeyEvent e) {
+    if (e is! RawKeyDownEvent) return;
+    final key = e.logicalKey;
+    int dx = 0, dy = 0;
+    if (key == LogicalKeyboardKey.arrowUp || key == LogicalKeyboardKey.keyW) dy = -1;
+    if (key == LogicalKeyboardKey.arrowDown || key == LogicalKeyboardKey.keyS) dy = 1;
+    if (key == LogicalKeyboardKey.arrowLeft || key == LogicalKeyboardKey.keyA) dx = -1;
+    if (key == LogicalKeyboardKey.arrowRight || key == LogicalKeyboardKey.keyD) dx = 1;
+    if (key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.space) actionRequested = true;
+    if (dx != 0 || dy != 0) {
+      setState(() {
+        playerX = (playerX + dx).clamp(0, widget.mapData.width - 1);
+        playerY = (playerY + dy).clamp(0, widget.mapData.height - 1);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final map = widget.mapData;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Aperçu Runtime')),
+      body: RawKeyboardListener(
+        autofocus: true,
+        focusNode: _focusNode,
+        onKey: _onKey,
+        child: Stack(
+          children: [
+            Center(
+              child: CustomPaint(
+                size: Size(map.width * tileSize, map.height * tileSize),
+                painter: _RuntimePainter(
+                  mapData: map,
+                  tileSize: tileSize,
+                  playerX: playerX,
+                  playerY: playerY,
+                  scene: widget.scene,
+                ),
+              ),
+            ),
+            if (message != null)
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  margin: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.7),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    message!,
+                    style: const TextStyle(color: Colors.white, fontSize: 16),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RuntimePainter extends CustomPainter {
+  _RuntimePainter({
+    required this.mapData,
+    required this.tileSize,
+    required this.playerX,
+    required this.playerY,
+    required this.scene,
+  });
+
+  final MapData mapData;
+  final double tileSize;
+  final int playerX;
+  final int playerY;
+  final SceneData scene;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bgA = Paint()..color = const Color(0xFF153B6F);
+    final bgB = Paint()..color = const Color(0xFF0F2F59);
+
+    // background checker
+    for (double y = 0; y < size.height; y += tileSize) {
+      for (double x = 0; x < size.width; x += tileSize) {
+        final isA = ((x / tileSize).floor() + (y / tileSize).floor()) % 2 == 0;
+        canvas.drawRect(Rect.fromLTWH(x, y, tileSize, tileSize), isA ? bgA : bgB);
+      }
+    }
+
+    // draw layers
+    void paintLayer(TileLayer layer, Color color) {
+      for (int y = 0; y < layer.height; y++) {
+        for (int x = 0; x < layer.width; x++) {
+          final t = layer.data[y][x];
+          if (t < 0) continue;
+          final r = Rect.fromLTWH(x * tileSize, y * tileSize, tileSize, tileSize);
+          canvas.drawRRect(RRect.fromRectAndRadius(r, const Radius.circular(2)), Paint()..color = color.withOpacity(0.35));
+        }
+      }
+    }
+
+    paintLayer(mapData.layers[MapLayerKind.layerA]!, const Color(0xFF64B5F6));
+    paintLayer(mapData.layers[MapLayerKind.layerB]!, const Color(0xFF81C784));
+    paintLayer(mapData.layers[MapLayerKind.layerC]!, const Color(0xFFA1887F));
+    paintLayer(mapData.layers[MapLayerKind.layerD]!, const Color(0xFFBA68C8));
+
+    // draw scene objects
+    for (final o in scene.objects) {
+      final rect = Rect.fromLTWH(o.x * tileSize, o.y * tileSize, tileSize, tileSize);
+      final paint = Paint()..color = Colors.orangeAccent.withOpacity(0.9);
+      canvas.drawRRect(RRect.fromRectAndRadius(rect.deflate(3), const Radius.circular(4)), paint);
+    }
+
+    // draw player
+    final playerCenter = Offset((playerX + 0.5) * tileSize, (playerY + 0.5) * tileSize);
+    canvas.drawCircle(playerCenter, tileSize * 0.35, Paint()..color = Colors.white);
+    canvas.drawCircle(playerCenter, tileSize * 0.35, Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2
+      ..color = Colors.black54);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RuntimePainter oldDelegate) {
+    return oldDelegate.mapData != mapData ||
+        oldDelegate.playerX != playerX ||
+        oldDelegate.playerY != playerY ||
+        oldDelegate.scene != scene;
+  }
+}

--- a/lib/scene_editor.dart
+++ b/lib/scene_editor.dart
@@ -1,0 +1,266 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'models.dart';
+
+class SceneEditorPage extends StatefulWidget {
+  const SceneEditorPage({
+    super.key,
+    required this.scene,
+    required this.mapData,
+    required this.is3D,
+    this.pendingAssetName,
+    this.onPendingAssetConsumed,
+  });
+
+  final SceneData scene;
+  final MapData mapData;
+  final bool is3D;
+  final String? pendingAssetName;
+  final VoidCallback? onPendingAssetConsumed;
+
+  @override
+  State<SceneEditorPage> createState() => _SceneEditorPageState();
+}
+
+class _SceneEditorPageState extends State<SceneEditorPage> {
+  static const double tileSize = 24.0;
+
+  String? selectedObjectId;
+  Offset? dragStartWorld;
+  int? dragStartObjX;
+  int? dragStartObjY;
+
+  @override
+  Widget build(BuildContext context) {
+    final scene = widget.scene;
+    final map = widget.mapData;
+    final Size canvasSize = Size(map.width * tileSize, map.height * tileSize);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildToolbar(),
+        Expanded(
+          child: Scrollbar(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.vertical,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTapDown: (details) => _onTap(details.localPosition),
+                  onPanStart: (details) => _onPanStart(details.localPosition),
+                  onPanUpdate: (details) => _onPanUpdate(details.localPosition),
+                  onPanEnd: (_) => _onPanEnd(),
+                  child: CustomPaint(
+                    size: canvasSize,
+                    painter: _ScenePainter(
+                      mapWidth: map.width,
+                      mapHeight: map.height,
+                      tileSize: tileSize,
+                      objects: scene.objects,
+                      selectedObjectId: selectedObjectId,
+                      is3D: widget.is3D,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToolbar() {
+    final pending = widget.pendingAssetName;
+    return Container(
+      height: 44,
+      color: const Color(0xFF165A9A),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        children: [
+          const Icon(Icons.view_in_ar, color: Colors.white),
+          const SizedBox(width: 8),
+          Text('Scène — ${widget.scene.name}', style: const TextStyle(color: Colors.white)),
+          const Spacer(),
+          if (pending != null)
+            Row(
+              children: [
+                const Icon(Icons.add_location_alt_outlined, color: Colors.white),
+                const SizedBox(width: 6),
+                Text('Cliquez pour placer: $pending', style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _onTap(Offset localPos) {
+    final grid = _pixelToGrid(localPos);
+
+    if (widget.pendingAssetName != null) {
+      final newObj = _createObjectFromAsset(widget.pendingAssetName!, grid.dx.toInt(), grid.dy.toInt());
+      setState(() {
+        widget.scene.objects.add(newObj);
+        selectedObjectId = newObj.id;
+      });
+      widget.onPendingAssetConsumed?.call();
+      return;
+    }
+
+    // Select object if any at position
+    final hit = _findTopmostObjectAt(grid.dx.toInt(), grid.dy.toInt());
+    setState(() {
+      selectedObjectId = hit?.id;
+    });
+  }
+
+  void _onPanStart(Offset localPos) {
+    final grid = _pixelToGrid(localPos);
+    final hit = _findTopmostObjectAt(grid.dx.toInt(), grid.dy.toInt());
+    if (hit == null) return;
+    setState(() {
+      selectedObjectId = hit.id;
+      dragStartWorld = localPos;
+      dragStartObjX = hit.x;
+      dragStartObjY = hit.y;
+    });
+  }
+
+  void _onPanUpdate(Offset localPos) {
+    if (selectedObjectId == null || dragStartWorld == null) return;
+    final dx = (localPos.dx - dragStartWorld!.dx) / tileSize;
+    final dy = (localPos.dy - dragStartWorld!.dy) / tileSize;
+    final obj = widget.scene.objects.firstWhere((o) => o.id == selectedObjectId);
+    setState(() {
+      obj.x = (dragStartObjX! + dx.round()).clamp(0, widget.mapData.width - 1);
+      obj.y = (dragStartObjY! + dy.round()).clamp(0, widget.mapData.height - 1);
+    });
+  }
+
+  void _onPanEnd() {
+    dragStartWorld = null;
+    dragStartObjX = null;
+    dragStartObjY = null;
+  }
+
+  Offset _pixelToGrid(Offset p) {
+    final gx = (p.dx / tileSize).floor().toDouble();
+    final gy = (p.dy / tileSize).floor().toDouble();
+    return Offset(gx, gy);
+  }
+
+  SceneObject? _findTopmostObjectAt(int x, int y) {
+    for (int i = widget.scene.objects.length - 1; i >= 0; i--) {
+      final o = widget.scene.objects[i];
+      if (o.x == x && o.y == y) return o;
+    }
+    return null;
+  }
+
+  SceneObject _createObjectFromAsset(String assetName, int x, int y) {
+    final kind = _inferKindFromAsset(assetName);
+    return SceneObject(
+      id: '${DateTime.now().microsecondsSinceEpoch}_${math.Random().nextInt(9999)}',
+      name: assetName,
+      kind: kind,
+      x: x,
+      y: y,
+      asset: assetName,
+    );
+  }
+
+  SceneObjectKind _inferKindFromAsset(String assetName) {
+    final lower = assetName.toLowerCase();
+    if (lower.endsWith('.glb') || lower.endsWith('.fbx') || lower.endsWith('.obj')) {
+      return SceneObjectKind.model3D;
+    }
+    return SceneObjectKind.sprite2D;
+  }
+}
+
+class _ScenePainter extends CustomPainter {
+  _ScenePainter({
+    required this.mapWidth,
+    required this.mapHeight,
+    required this.tileSize,
+    required this.objects,
+    required this.selectedObjectId,
+    required this.is3D,
+  });
+
+  final int mapWidth;
+  final int mapHeight;
+  final double tileSize;
+  final List<SceneObject> objects;
+  final String? selectedObjectId;
+  final bool is3D;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Checker background
+    final bgA = Paint()..color = const Color(0xFF153B6F);
+    final bgB = Paint()..color = const Color(0xFF0F2F59);
+    for (double y = 0; y < size.height; y += tileSize) {
+      for (double x = 0; x < size.width; x += tileSize) {
+        final isA = ((x / tileSize).floor() + (y / tileSize).floor()) % 2 == 0;
+        canvas.drawRect(Rect.fromLTWH(x, y, tileSize, tileSize), isA ? bgA : bgB);
+      }
+    }
+
+    // Grid
+    final gridPaint = Paint()
+      ..color = Colors.white12
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+    for (int x = 0; x <= mapWidth; x++) {
+      final dx = x * tileSize;
+      canvas.drawLine(Offset(dx, 0), Offset(dx, mapHeight * tileSize), gridPaint);
+    }
+    for (int y = 0; y <= mapHeight; y++) {
+      final dy = y * tileSize;
+      canvas.drawLine(Offset(0, dy), Offset(mapWidth * tileSize, dy), gridPaint);
+    }
+
+    // Draw objects
+    for (final o in objects) {
+      final rect = Rect.fromLTWH(o.x * tileSize, o.y * tileSize, tileSize, tileSize);
+      final color = _colorFor(o);
+      final rrect = RRect.fromRectAndRadius(rect.deflate(3), const Radius.circular(4));
+      canvas.drawRRect(rrect, Paint()..color = color);
+      if (o.id == selectedObjectId) {
+        canvas.drawRRect(rrect, Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..color = Colors.yellowAccent);
+      }
+    }
+  }
+
+  Color _colorFor(SceneObject o) {
+    switch (o.kind) {
+      case SceneObjectKind.model3D:
+        return const Color(0xFF8BC34A);
+      case SceneObjectKind.light:
+        return const Color(0xFFFFF176);
+      case SceneObjectKind.camera:
+        return const Color(0xFF80DEEA);
+      case SceneObjectKind.sound:
+        return const Color(0xFFFFB74D);
+      case SceneObjectKind.sprite2D:
+      default:
+        return const Color(0xFF64B5F6);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _ScenePainter oldDelegate) {
+    return oldDelegate.objects != objects ||
+        oldDelegate.selectedObjectId != selectedObjectId ||
+        oldDelegate.mapWidth != mapWidth ||
+        oldDelegate.mapHeight != mapHeight ||
+        oldDelegate.is3D != is3D;
+  }
+}


### PR DESCRIPTION
Add scene editor and runtime preview to support scene object placement and basic event execution.

This PR implements the initial versions of a scene editor and a runtime preview, allowing users to place objects on a scene grid and test basic event interactions within a simplified runtime environment, as requested by the task.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b66bb50-bf1d-405b-9582-88f24bb19f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b66bb50-bf1d-405b-9582-88f24bb19f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

