### PR TITLE
Add classes database tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prototype d'éditeur inspiré de RPG Maker VX Ace développé avec Flutter.
 ## Caractéristiques
 
 - Édition de cartes et de scènes en 2D, 2,5D et 3D.
-- Base de données pour gérer héros, ennemis, tilesets, objets, compétences, états et statistiques.
+- Base de données pour gérer héros, classes, ennemis, tilesets, objets, compétences, états et statistiques.
 - Support des projectiles et désormais des animations d'acteur et VFX.
 
 Ce projet est en cours de développement et sert de terrain d'expérimentation.


### PR DESCRIPTION
## Summary
- support character class definitions with `ClassDef`
- add new Classes tab in database window for editing class stats and description
- document database now includes classes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b82211478c832abab2526c59c4d39b