### PR TITLE
feat: add class and tileset database editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Prototype d'éditeur inspiré de RPG Maker VX Ace développé avec Flutter.
 ## Caractéristiques
 
 - Édition de cartes et de scènes en 2D, 2,5D et 3D.
-- Base de données pour gérer héros, ennemis, tilesets, objets, compétences, états et statistiques.
-- Support des projectiles et désormais des animations d'acteur et VFX.
+- Base de données pour gérer héros, classes, ennemis, tilesets, objets, compétences, états et statistiques.
+- Les tilesets regroupent des listes d'assets 2D et 3D.
+- Support des projectiles et des animations d'acteur (mouvements) et VFX.
 
 Ce projet est en cours de développement et sert de terrain d'expérimentation.


### PR DESCRIPTION
## Summary
- define `ClassDef` and `TilesetDef` models for database entries
- add database tabs for editing classes and tilesets with 2D/3D assets
- document classes and tilesets in project README

## Testing
- `dart format lib/main.dart README.md` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b82855479c832ab28f14b8c3b3d95a