### PR TITLE
Add toolbar toggle helper

### DIFF
--- a/lib/map_editor.dart
+++ b/lib/map_editor.dart
@@ -218,6 +218,16 @@ class _MapEditorPageState extends State<MapEditorPage> {
     );
   }
 
+  Widget _toggle(String label, bool value, ValueChanged<bool> onChanged) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(label, style: const TextStyle(color: Colors.white)),
+        Switch(value: value, onChanged: onChanged),
+      ],
+    );
+  }
+
   Widget _buildPalette() {
     final entries = palette.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
     return SizedBox(


### PR DESCRIPTION
## Summary
- fix missing toggle builder in map editor toolbar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b95ef072a0832a8ae4118eaee07d25